### PR TITLE
fix(kik): pass correct url parameters to kik bot

### DIFF
--- a/broid-kik/README.md
+++ b/broid-kik/README.md
@@ -98,6 +98,8 @@ app.use("/kik", kik.getRouter());
 app.listen(8080);
 ```
 
+When using the kik integration in an express application, ensure that you do **not** mount any kind of `body-parser` middleware before the router. The official kik library [expects to handle a raw body itself](https://github.com/kikinteractive/kik-node/issues/8).
+
 **Options available**
 
 | name             | Type     | default    | Description  |

--- a/broid-kik/src/core/Adapter.ts
+++ b/broid-kik/src/core/Adapter.ts
@@ -6,8 +6,8 @@ import * as Promise from 'bluebird';
 import { Router  } from 'express';
 import * as uuid from 'node-uuid';
 import * as R from 'ramda';
-import * as url from 'url';
 import { Observable } from 'rxjs/Rx';
+import * as url from 'url';
 
 import { IAdapterOptions } from './interfaces';
 import { Parser } from './Parser';
@@ -87,18 +87,17 @@ export class Adapter {
     }
 
     const webhookURL = url.parse(this.webhookURL);
-
-    const options: any = {
+    const kikOptions: any = {
       apiKey: this.token,
       baseUrl: `${webhookURL.protocol}//${webhookURL.hostname}`,
-      username: this.username
+      username: this.username,
     };
 
     if (webhookURL.path) {
-      options.incomingPath = `${webhookURL.path}/incoming`;
+      kikOptions.incomingPath = `${webhookURL.path}/incoming`;
     }
 
-    this.session = new KikBot(options);
+    this.session = new KikBot(kikOptions);
 
     this.router.get('/', (req: any, res: any) => {
       const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;

--- a/broid-kik/src/core/Adapter.ts
+++ b/broid-kik/src/core/Adapter.ts
@@ -168,14 +168,21 @@ export class Adapter {
             if (dataType === 'Image' || dataType === 'Video') {
               const url = R.path(['object', 'url'], data);
               const name = R.path(['object', 'name'], data) || '';
+              const preview = R.path(['object', 'preview'], data) || url;
 
-              let message = KikBot.Message.picture(url)
-                .setAttributionName(name)
-                .setAttributionIcon(R.path(['object', 'preview'], data) || url);
+              let message;
+              if (dataType === 'Image') {
+                message = KikBot.Message.picture(url);
+              }
               if (dataType === 'Video') {
-                message = KikBot.Message.video(url)
-                  .setAttributionName(name)
-                  .setAttributionIcon(R.path(['object', 'preview'], data));
+                message = KikBot.Message.video(url);
+              }
+
+              if (message && name) {
+                message.setAttributionName(name);
+              }
+              if (message && preview) {
+                message.setAttributionIcon(preview);
               }
 
               return [btns, message];

--- a/broid-kik/src/core/Adapter.ts
+++ b/broid-kik/src/core/Adapter.ts
@@ -94,7 +94,7 @@ export class Adapter {
     };
 
     if (webhookURL.path) {
-      kikOptions.incomingPath = `${webhookURL.path}/incoming`;
+      kikOptions.incomingPath = `${webhookURL.path}incoming`;
     }
 
     this.session = new KikBot(kikOptions);

--- a/broid-kik/src/core/Parser.ts
+++ b/broid-kik/src/core/Parser.ts
@@ -44,13 +44,13 @@ export class Parser {
     if (!normalized || R.isEmpty(normalized)) { return Promise.resolve(null); }
 
     const activitystreams = this.createActivityStream(normalized);
-    activitystreams.actor = {
+    activitystreams.target = {
       id: normalized.from.id.toString(),
       name: concat([normalized.from.firstName, normalized.from.lastName]),
       type: 'Person',
     };
 
-    activitystreams.target = {
+    activitystreams.actor = {
       id: normalized.chatID.toString(),
       name: normalized.chatID.toString(),
       type: 'Person',


### PR DESCRIPTION
The current `kik` integration does not work if you pass a `webhookURL` that contains a path fragment as the kik library will strip the path and use the base URL only: https://github.com/kikinteractive/kik-node/blob/90f062b20c53109d34bc4dfeca332c54ee348d43/lib/bot.js#L141

This results in kik calling `http://foo.bar/incoming` when you pass `http://foo.bar/my-bot/kik` as webhook URL value (expecting kik to call `http://foo.bar/my-bot/kik`).

I am not 100% sure if this fix makes sense though, so please have a thorough look.