### PR TITLE
docs(slack): add instructions on how to obtain token

### DIFF
--- a/broid-slack/README.md
+++ b/broid-slack/README.md
@@ -114,6 +114,17 @@ app.listen(8080);
 | token           | string   |            | Your access token |
 | http             | object   |            | WebServer options (`host`, `port`) |
 
+
+### Generate the "Bot User Token"
+
+`broid-slack` needs the "Bot User Token" to authenticate against the Slack RTM and Web Client. To obtain this client, you can use the script at `bin/oauth.js`. You will need your "Client ID" and your "Client Secret":
+
+```sh
+$ ./oauth.js --new --clientID xxxxxxxxxxxxxxxxxxxxxxxxx --clientSecret yyyyyyyyyyyyyyyyyyyyyyyyyyyy
+```
+
+This will open your default web browser and guide you to obtain the needeed token (easily spotted starting with: `xoxp-`). Alternatively you can obtain a "Legacy Token" [here](https://api.slack.com/custom-integrations/legacy-tokens).
+
 ### Receive a message
 
 ```javascript

--- a/broid-slack/bin/oauth.js
+++ b/broid-slack/bin/oauth.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env babel-node --
+#!/usr/bin/env node
 
 const express = require("express");
 const bodyParser = require("body-parser");

--- a/broid-slack/src/core/Adapter.ts
+++ b/broid-slack/src/core/Adapter.ts
@@ -114,7 +114,7 @@ export class Adapter {
       });
     const disconnected = Observable
       .fromEvent(this.session, CLIENT_EVENTS.RTM.DISCONNECT)
-      .map(() => Promise.resolve({ type: 'connected', serviceID: this.serviceId() }));
+      .map(() => Promise.resolve({ type: 'disconnected', serviceID: this.serviceId() }));
     const rateLimited = Observable
       .fromEvent(this.session, CLIENT_EVENTS.WEB.RATE_LIMITED)
       .map(() => Promise.resolve({ type: 'rate_limited', serviceID: this.serviceId() }));


### PR DESCRIPTION
It took me quite a while to get how to configure the slack integration as the slack docs and terminology are terribly confusing. Broid comes with a handy script to do that, but it is not mentioned anywhere.

Also (considering broid requires node 6) there is no need to run the script using babel-node.

Also, fix a typo in the adapater, correcting the sent event on RTM disconnect. 