### PR TITLE
fix(twitter):  Adapter.js user not found error

### DIFF
--- a/broid-twitter/src/core/Adapter.ts
+++ b/broid-twitter/src/core/Adapter.ts
@@ -131,9 +131,9 @@ export class Adapter {
 
         event._username = this.username;
 
-        if (event.in_reply_to_user_id) {
+        if (event.in_reply_to_user_id_str) {
           // mention
-          return this.userById(event.in_reply_to_user_id, true)
+          return this.userById(event.in_reply_to_user_id_str, true)
             .then((data) => {
               event.recipient = R.assoc('is_mention', true, data);
               return event;


### PR DESCRIPTION
Issue: `User not found` error occurs when listening for a Tweet 

Changing `event.in_reply_to_user_id` to use `event.in_reply_to_user_id_str `   as described in https://dev.twitter.com/overview/api/twitter-ids-json-and-snowflake fixes user not found error.

From Twitter Documentation 



> When consuming the API using JSON, it is important to always use the field id_str instead of id. This is due to the way Javascript and other languages that consume JSON evaluate large integers. If you come across a scenario where it doesn’t appear that id and id_str match, it’s due to your environment having already parsed the id integer, munging the number in the process. Read below for more information on how Twitter generates its ids.



Fixing `user not found` in  broid twitter integration. 