### PR TITLE
Fix(wechat): Updating the wechat npm module

### DIFF
--- a/broid-twitter/src/core/Adapter.ts
+++ b/broid-twitter/src/core/Adapter.ts
@@ -131,9 +131,9 @@ export class Adapter {
 
         event._username = this.username;
 
-        if (event.in_reply_to_user_id) {
+        if (event.in_reply_to_user_id_str) {
           // mention
-          return this.userById(event.in_reply_to_user_id, true)
+          return this.userById(event.in_reply_to_user_id_str, true)
             .then((data) => {
               event.recipient = R.assoc('is_mention', true, data);
               return event;


### PR DESCRIPTION
Fix(wechat): Updating the wechat npm module

Fixing issue where Broid wechat would throw the following error when receiving a message over the wechat api

`Cannot read property '0' of undefined`

