### PR TITLE
docs: Add slackin badge and link to all READMEs

### DIFF
--- a/broid-alexa/README.md
+++ b/broid-alexa/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-callr/README.md
+++ b/broid-callr/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-discord/README.md
+++ b/broid-discord/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-flowdock/README.md
+++ b/broid-flowdock/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-gitter/README.md
+++ b/broid-gitter/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-google-assistant/README.md
+++ b/broid-google-assistant/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-groupme/README.md
+++ b/broid-groupme/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-irc/README.md
+++ b/broid-irc/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-kik/README.md
+++ b/broid-kik/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-line/README.md
+++ b/broid-line/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-messenger/README.md
+++ b/broid-messenger/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-ms-teams/README.md
+++ b/broid-ms-teams/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-nexmo/README.md
+++ b/broid-nexmo/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-skype/README.md
+++ b/broid-skype/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-slack/README.md
+++ b/broid-slack/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-telegram/README.md
+++ b/broid-telegram/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-twilio/README.md
+++ b/broid-twilio/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-twitter/README.md
+++ b/broid-twitter/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-viber/README.md
+++ b/broid-viber/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 

--- a/broid-wechat/README.md
+++ b/broid-wechat/README.md
@@ -34,6 +34,7 @@ Broid Integrations is an open source project providing a suite of Activity Strea
 > Connect your App to Multiple Messaging Channels with  One OpenSource Language.
 
 [![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)
+[![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)
 
 ## Message types supported
 


### PR DESCRIPTION
Updates integration package level README.md files, adding a slackin badge to right of the gitter badge.

Fixes #106 

Before:
[![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter)

After:
[![gitter](https://badges.gitter.im/broidHQ/broid.svg)](https://t.broid.ai/c/Blwjlw?utm_source=github&utm_medium=readme&utm_campaign=top&link=gitter) [![slackin](https://slackin.broid.ai/badge.svg)](https://slackin.broid.ai)

