### PR TITLE
Updated redirection link to the Broid Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ This make Broid **flexible** and **useful** to use in your application.
 
 ### Broid Formats
 
-Broid integrations supports [Activity Streams 2.0](https://t.broid.ai/c/LSB12U?utm_source=github&utm_medium=readme&utm_campaign=formats&link=as2) and uses [broid-schemas](https://t.broid.ai/c/gepuZo?utm_source=github&utm_medium=readme&utm_campaign=formats&link=github-broid-schemas) package to validate input and output message.
+Broid integrations supports [Activity Streams 2.0](https://t.broid.ai/c/LSB12U?utm_source=github&utm_medium=readme&utm_campaign=formats&link=as2) and uses [broid-schemas](https://t.broid.ai/c/U3AMg8?utm_source=github&utm_medium=readme&utm_campaign=formats&link=github-broid-schemas) package to validate input and output message.
 
 
 |Name|Status|


### PR DESCRIPTION
Old:
https://goo.gl/gepuZo = https://github.com/broidHQ/integrations/tree/master/integrations/broid-schemas 
New:
https://goo.gl/U3AMg8 = https://github.com/broidHQ/integrations/tree/master/broid-schemas